### PR TITLE
force cargo fmt

### DIFF
--- a/src/btrfs_volume_metadata.rs
+++ b/src/btrfs_volume_metadata.rs
@@ -1,7 +1,7 @@
-use std::path::{PathBuf};
-use color_eyre::Result;
 use crate::config::*;
 use crate::provisioner::Provisioner;
+use color_eyre::Result;
+use std::path::PathBuf;
 
 /// Represents a BTRFS volume from the provisioner's perspective.
 /// The volume doesn't necessarily need to exist yet.
@@ -18,9 +18,6 @@ impl BtrfsVolumeMetadata {
         let path: PathBuf = path_parts.iter().collect();
         let host_path = Provisioner::get_host_path(&path_parts)?;
 
-        Ok(BtrfsVolumeMetadata {
-            path,
-            host_path,
-        })
+        Ok(BtrfsVolumeMetadata { path, host_path })
     }
 }

--- a/src/btrfs_wrapper.rs
+++ b/src/btrfs_wrapper.rs
@@ -1,10 +1,10 @@
-use std::io::{stderr, stdout, Write};
-use std::process::{Command, Output};
+use crate::config::*;
 use color_eyre::eyre::bail;
 use color_eyre::Result;
 use lazy_static::lazy_static;
 use regex::Regex;
-use crate::config::*;
+use std::io::{stderr, stdout, Write};
+use std::process::{Command, Output};
 
 pub struct BtrfsWrapper {
     chroot_to_host: bool,
@@ -44,7 +44,10 @@ impl BtrfsWrapper {
     }
 
     pub fn qgroup_limit(&self, bytes: u64, path: &str) -> Result<Output> {
-        self.run_command("btrfs", &["qgroup", "limit", bytes.to_string().as_str(), path])
+        self.run_command(
+            "btrfs",
+            &["qgroup", "limit", bytes.to_string().as_str(), path],
+        )
     }
 
     pub fn qgroup_destroy(&self, qgroup: &str, path: &str) -> Result<Output> {
@@ -94,14 +97,11 @@ impl BtrfsWrapper {
                     Command::new("chroot")
                         .args(vec![path.as_str(), command])
                         .args(args),
-                )
+                );
             }
         }
 
-        let output = run_prepared_command(
-            Command::new(command)
-                .args(args),
-        )?;
+        let output = run_prepared_command(Command::new(command).args(args))?;
 
         if !&output.status.success() {
             bail!("`btrfs {}` failed: {}", &args.join(" "), &output.status);

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,8 @@
 use lazy_static::lazy_static;
 
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
-pub const STORAGE_CLASS_CONTROLLING_NODE_LABEL_NAME: &str = "btrfs-provisioner.timo.schwarzer.dev/node";
+pub const STORAGE_CLASS_CONTROLLING_NODE_LABEL_NAME: &str =
+    "btrfs-provisioner.timo.schwarzer.dev/node";
 pub const PROVISIONED_BY_ANNOTATION_KEY: &str = "pv.kubernetes.io/provisioned-by";
 pub const PROVISIONER_NAME: &str = "timo.schwarzer.dev/btrfs-provisioner";
 pub const FINALIZER_NAME: &str = "timo.schwarzer.dev/btrfs-provisioner";
@@ -10,16 +11,39 @@ pub const SERVICE_ACCOUNT_NAME: &str = "btrfs-provisioner-service-account";
 pub const HOST_FS_ENV_NAME: &str = "HOST_FS";
 
 lazy_static! {
-    pub static ref NAMESPACE: String = std::env::var("NAMESPACE").unwrap_or_else(|_| "btrfs-provisioner".into());
-    pub static ref VOLUMES_DIR: String = std::env::var("VOLUMES_DIR").unwrap_or_else(|_| "/volumes".into());
-    pub static ref IMAGE: String = std::env::var("IMAGE").unwrap_or_else(|_| "ghcr.io/timoschwarzer/btrfs-provisioner".into());
-    pub static ref ARCHIVE_ON_DELETE: bool = matches!(std::env::var("ARCHIVE_ON_DELETE").unwrap_or_else(|_| "false".into()).as_str(), "true" | "1");
-    pub static ref DYNAMIC_STORAGE_CLASS_ENABLED: bool = matches!(std::env::var("DYNAMIC_STORAGE_CLASS").unwrap_or_else(|_| "false".into()).as_str(), "true" | "1");
-    pub static ref DYNAMIC_STORAGE_CLASS_NAME: String = std::env::var("DYNAMIC_STORAGE_CLASS_NAME").unwrap_or_else(|_| "btrfs-provisioner".into());
-    pub static ref STORAGE_CLASS_PER_NODE_ENABLED: bool = matches!(std::env::var("STORAGE_CLASS_PER_NODE").unwrap_or_else(|_| "true".into()).as_str(), "true" | "1");
+    pub static ref NAMESPACE: String =
+        std::env::var("NAMESPACE").unwrap_or_else(|_| "btrfs-provisioner".into());
+    pub static ref VOLUMES_DIR: String =
+        std::env::var("VOLUMES_DIR").unwrap_or_else(|_| "/volumes".into());
+    pub static ref IMAGE: String =
+        std::env::var("IMAGE").unwrap_or_else(|_| "ghcr.io/timoschwarzer/btrfs-provisioner".into());
+    pub static ref ARCHIVE_ON_DELETE: bool = matches!(
+        std::env::var("ARCHIVE_ON_DELETE")
+            .unwrap_or_else(|_| "false".into())
+            .as_str(),
+        "true" | "1"
+    );
+    pub static ref DYNAMIC_STORAGE_CLASS_ENABLED: bool = matches!(
+        std::env::var("DYNAMIC_STORAGE_CLASS")
+            .unwrap_or_else(|_| "false".into())
+            .as_str(),
+        "true" | "1"
+    );
+    pub static ref DYNAMIC_STORAGE_CLASS_NAME: String =
+        std::env::var("DYNAMIC_STORAGE_CLASS_NAME").unwrap_or_else(|_| "btrfs-provisioner".into());
+    pub static ref STORAGE_CLASS_PER_NODE_ENABLED: bool = matches!(
+        std::env::var("STORAGE_CLASS_PER_NODE")
+            .unwrap_or_else(|_| "true".into())
+            .as_str(),
+        "true" | "1"
+    );
     pub static ref STORAGE_CLASS_PER_NODE_NAME_PATTERN: String = {
-        let pattern = std::env::var("STORAGE_CLASS_PER_NODE_NAME_PATTERN").unwrap_or_else(|_| "btrfs-provisioner-{}".into());
-        assert!(pattern.contains("{}"), "STORAGE_CLASS_PER_NODE_NAME_PATTERN must contain a {{}} placeholder");
+        let pattern = std::env::var("STORAGE_CLASS_PER_NODE_NAME_PATTERN")
+            .unwrap_or_else(|_| "btrfs-provisioner-{}".into());
+        assert!(
+            pattern.contains("{}"),
+            "STORAGE_CLASS_PER_NODE_NAME_PATTERN must contain a {{}} placeholder"
+        );
         pattern
     };
 }

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -1,20 +1,29 @@
+use color_eyre::eyre::eyre;
 use std::collections::{BTreeMap, HashSet};
-use color_eyre::eyre::{eyre};
 
 use color_eyre::Result;
 use futures_util::{stream, StreamExt, TryStreamExt};
 use k8s_openapi::api::batch::v1::{Job, JobSpec};
-use k8s_openapi::api::core::v1::{Container, EnvVar, EnvVarSource, HostPathVolumeSource, Node, ObjectFieldSelector, PersistentVolume, PersistentVolumeClaim, PersistentVolumeClaimSpec, PersistentVolumeClaimStatus, PersistentVolumeSpec, PodSpec, PodTemplateSpec, SecurityContext, Volume, VolumeMount};
+use k8s_openapi::api::core::v1::{
+    Container, EnvVar, EnvVarSource, HostPathVolumeSource, Node, ObjectFieldSelector,
+    PersistentVolume, PersistentVolumeClaim, PersistentVolumeClaimSpec,
+    PersistentVolumeClaimStatus, PersistentVolumeSpec, PodSpec, PodTemplateSpec, SecurityContext,
+    Volume, VolumeMount,
+};
 use k8s_openapi::api::storage::v1::StorageClass;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-use kube::{Api, Client, Config, ResourceExt};
 use kube::api::{ListParams, PostParams};
-use kube::runtime::{reflector, watcher};
 use kube::runtime::watcher::Event;
+use kube::runtime::{reflector, watcher};
+use kube::{Api, Client, Config, ResourceExt};
 
 use crate::config::*;
-use crate::controller::provisioner_job_type::{DeleteJobArgs, InitializeNodeJobArgs, ProvisionerJobType, ProvisionJobArgs};
-use crate::controller::storage_class_utils::{get_node_assigned_to_storage_class, is_controlling_storage_class, StorageClassNodeAssignment};
+use crate::controller::provisioner_job_type::{
+    DeleteJobArgs, InitializeNodeJobArgs, ProvisionJobArgs, ProvisionerJobType,
+};
+use crate::controller::storage_class_utils::{
+    get_node_assigned_to_storage_class, is_controlling_storage_class, StorageClassNodeAssignment,
+};
 use crate::ext::ProvisionerResourceExt;
 
 pub mod provisioner_job_type;
@@ -51,7 +60,11 @@ impl Controller {
     pub async fn create() -> Result<Self> {
         let client = Client::try_default()
             .await
-            .or_else(|_| Client::try_from(Config::incluster_env().expect("Failed to load in-cluster Kube config")))
+            .or_else(|_| {
+                Client::try_from(
+                    Config::incluster_env().expect("Failed to load in-cluster Kube config"),
+                )
+            })
             .expect("Failed to create Kube client");
 
         Ok(Controller {
@@ -90,17 +103,33 @@ impl Controller {
         let (_, pvc_writer) = reflector::store();
         let (_, pv_writer) = reflector::store();
         let (_, node_writer) = reflector::store();
-        let pvc_reflector = reflector(pvc_writer, watcher(persistent_volume_claims, watcher::Config::default()))
-            .map_ok(WatchedResource::Pvc);
-        let pv_reflector = reflector(pv_writer, watcher(persistent_volumes, watcher::Config::default()))
-            .map_ok(WatchedResource::Pv);
-        let node_reflector = reflector(node_writer, watcher(nodes, watcher::Config {
-            label_selector: Some("!node-role.kubernetes.io/master".into()),
-            ..watcher::Config::default()
-        }))
-            .map_ok(WatchedResource::Node);
+        let pvc_reflector = reflector(
+            pvc_writer,
+            watcher(persistent_volume_claims, watcher::Config::default()),
+        )
+        .map_ok(WatchedResource::Pvc);
+        let pv_reflector = reflector(
+            pv_writer,
+            watcher(persistent_volumes, watcher::Config::default()),
+        )
+        .map_ok(WatchedResource::Pv);
+        let node_reflector = reflector(
+            node_writer,
+            watcher(
+                nodes,
+                watcher::Config {
+                    label_selector: Some("!node-role.kubernetes.io/master".into()),
+                    ..watcher::Config::default()
+                },
+            ),
+        )
+        .map_ok(WatchedResource::Node);
 
-        let stream = stream::select_all(vec![pvc_reflector.boxed(), pv_reflector.boxed(), node_reflector.boxed()]);
+        let stream = stream::select_all(vec![
+            pvc_reflector.boxed(),
+            pv_reflector.boxed(),
+            node_reflector.boxed(),
+        ]);
 
         tokio::pin!(stream);
 
@@ -112,7 +141,7 @@ impl Controller {
                 WatchedResource::Pv(pv) => self.process_pv_event(pv).await?,
                 WatchedResource::Node(node) => self.process_node_event(node).await?,
             }
-        };
+        }
 
         Ok(())
     }
@@ -120,7 +149,19 @@ impl Controller {
     /// Process updates to PVCs
     async fn process_pvc_event(&mut self, event: Event<PersistentVolumeClaim>) -> Result<()> {
         for claim in event.into_iter_applied() {
-            if let PersistentVolumeClaim { spec: Some(PersistentVolumeClaimSpec { storage_class_name: Some(storage_class_name), .. }), status: Some(PersistentVolumeClaimStatus { phase: Some(phase), .. }), .. } = &claim {
+            if let PersistentVolumeClaim {
+                spec:
+                    Some(PersistentVolumeClaimSpec {
+                        storage_class_name: Some(storage_class_name),
+                        ..
+                    }),
+                status:
+                    Some(PersistentVolumeClaimStatus {
+                        phase: Some(phase), ..
+                    }),
+                ..
+            } = &claim
+            {
                 // Ignore any PVCs not controlled by one of our storage classes
                 if !is_controlling_storage_class(self.client(), storage_class_name).await? {
                     continue;
@@ -140,16 +181,30 @@ impl Controller {
                             let claim_namespace = &claim.namespace().unwrap();
                             let claim_name = &claim.name_any();
 
-                            let assigned_node = get_node_assigned_to_storage_class(self.client(), storage_class_name)
-                                .await?
-                                .ok_or_else(|| eyre!("No node assigned with StorageClass"))?;
+                            let assigned_node = get_node_assigned_to_storage_class(
+                                self.client(),
+                                storage_class_name,
+                            )
+                            .await?
+                            .ok_or_else(|| eyre!("No node assigned with StorageClass"))?;
 
                             match assigned_node {
                                 StorageClassNodeAssignment::SingleNode { node_name } => {
-                                    println!("Deploying volume provisioning job on Node {}", node_name);
-                                    if let Err(e) = self.run_provisioner_job("provision-volume", &node_name, &["provision", claim_namespace, claim_name], ProvisionerJobType::Provision(ProvisionJobArgs {
-                                        target_pvc_uid: uid.to_owned(),
-                                    })).await {
+                                    println!(
+                                        "Deploying volume provisioning job on Node {}",
+                                        node_name
+                                    );
+                                    if let Err(e) = self
+                                        .run_provisioner_job(
+                                            "provision-volume",
+                                            &node_name,
+                                            &["provision", claim_namespace, claim_name],
+                                            ProvisionerJobType::Provision(ProvisionJobArgs {
+                                                target_pvc_uid: uid.to_owned(),
+                                            }),
+                                        )
+                                        .await
+                                    {
                                         eprintln!("{}", e);
                                     }
                                 }
@@ -182,15 +237,15 @@ impl Controller {
     async fn process_pv_event(&mut self, event: Event<PersistentVolume>) -> Result<()> {
         for volume in event.into_iter_applied() {
             if let PersistentVolume {
-                metadata: ObjectMeta {
-                    uid: Some(uid), ..
-                },
-                spec: Some(
-                    PersistentVolumeSpec {
-                        storage_class_name: Some(storage_class_name), ..
-                    }
-                ), ..
-            } = &volume {
+                metadata: ObjectMeta { uid: Some(uid), .. },
+                spec:
+                    Some(PersistentVolumeSpec {
+                        storage_class_name: Some(storage_class_name),
+                        ..
+                    }),
+                ..
+            } = &volume
+            {
                 // Ignore any PVs not controlled by one of our storage classes
                 if !is_controlling_storage_class(self.client(), storage_class_name).await? {
                     continue;
@@ -198,11 +253,15 @@ impl Controller {
 
                 // Delete requested volumes
                 if let PersistentVolume {
-                    metadata: ObjectMeta {
-                        deletion_timestamp: Some(_),
-                        finalizers: Some(ref finalizers), ..
-                    }, ..
-                } = volume {
+                    metadata:
+                        ObjectMeta {
+                            deletion_timestamp: Some(_),
+                            finalizers: Some(ref finalizers),
+                            ..
+                        },
+                    ..
+                } = volume
+                {
                     // Skip volume if it doesn't have our finalizer anymore
                     if !finalizers.iter().any(|f| f == FINALIZER_NAME) {
                         continue;
@@ -213,21 +272,41 @@ impl Controller {
                             let nodes = Api::<Node>::all(self.client());
 
                             // Find the node name from the node hostname
-                            let volume_nodes = nodes.list(&ListParams {
-                                label_selector: Some(format!("{}={}", NODE_HOSTNAME_KEY, node_hostname)),
-                                limit: Some(1),
-                                ..ListParams::default()
-                            }).await?;
+                            let volume_nodes = nodes
+                                .list(&ListParams {
+                                    label_selector: Some(format!(
+                                        "{}={}",
+                                        NODE_HOSTNAME_KEY, node_hostname
+                                    )),
+                                    limit: Some(1),
+                                    ..ListParams::default()
+                                })
+                                .await?;
 
-                            if let Some(node_name) = &volume_nodes.items.get(0).and_then(|i| i.metadata.name.as_ref()) {
+                            if let Some(node_name) = &volume_nodes
+                                .items
+                                .get(0)
+                                .and_then(|i| i.metadata.name.as_ref())
+                            {
                                 println!("Deploying volume deletion job on Node {}", node_name);
-                                if let Err(e) = self.run_provisioner_job("delete-volume", node_name, &["delete", volume.name_any().as_str()], ProvisionerJobType::Delete(DeleteJobArgs {
-                                    target_pv_uid: uid.to_owned(),
-                                })).await {
+                                if let Err(e) = self
+                                    .run_provisioner_job(
+                                        "delete-volume",
+                                        node_name,
+                                        &["delete", volume.name_any().as_str()],
+                                        ProvisionerJobType::Delete(DeleteJobArgs {
+                                            target_pv_uid: uid.to_owned(),
+                                        }),
+                                    )
+                                    .await
+                                {
                                     eprintln!("{}", e);
                                 }
                             } else {
-                                eprintln!("Did not find node with {}={}", NODE_HOSTNAME_KEY, node_hostname)
+                                eprintln!(
+                                    "Did not find node with {}={}",
+                                    NODE_HOSTNAME_KEY, node_hostname
+                                )
                             }
 
                             continue;
@@ -253,19 +332,38 @@ impl Controller {
             if let Some(uid) = &node.metadata.uid {
                 let storage_classes = Api::<StorageClass>::all(self.client());
 
-                if let [existing_storage_class] = storage_classes.list(&ListParams {
-                    label_selector: Some(format!("{}={}", STORAGE_CLASS_CONTROLLING_NODE_LABEL_NAME, &node.name_any())),
-                    limit: Some(1),
-                    ..ListParams::default()
-                }).await?.items.as_slice() {
-                    println!("Node {} is associated with StorageClass {}", node.name_any(), existing_storage_class.name_any());
+                if let [existing_storage_class] = storage_classes
+                    .list(&ListParams {
+                        label_selector: Some(format!(
+                            "{}={}",
+                            STORAGE_CLASS_CONTROLLING_NODE_LABEL_NAME,
+                            &node.name_any()
+                        )),
+                        limit: Some(1),
+                        ..ListParams::default()
+                    })
+                    .await?
+                    .items
+                    .as_slice()
+                {
+                    println!(
+                        "Node {} is associated with StorageClass {}",
+                        node.name_any(),
+                        existing_storage_class.name_any()
+                    );
                     continue;
                 }
 
                 println!("Initializing Node {}", node.name_any());
-                self.run_provisioner_job("initialize-node", &node.name_any(), &["initialize-node"], ProvisionerJobType::InitializeNode(InitializeNodeJobArgs {
-                    target_node_uid: uid.to_owned(),
-                })).await?;
+                self.run_provisioner_job(
+                    "initialize-node",
+                    &node.name_any(),
+                    &["initialize-node"],
+                    ProvisionerJobType::InitializeNode(InitializeNodeJobArgs {
+                        target_node_uid: uid.to_owned(),
+                    }),
+                )
+                .await?;
             }
         }
 
@@ -275,11 +373,16 @@ impl Controller {
     /// Tries to extract the Node hostname from a [PersistentVolume] by looking at the `nodeAffinity` field.
     fn get_node_hostname_from_node_affinity(volume: &PersistentVolume) -> Option<String> {
         volume
-            .spec.as_ref()?
-            .node_affinity.as_ref()?
-            .required.as_ref()?
-            .node_selector_terms.get(0)?
-            .match_expressions.as_ref()?
+            .spec
+            .as_ref()?
+            .node_affinity
+            .as_ref()?
+            .required
+            .as_ref()?
+            .node_selector_terms
+            .get(0)?
+            .match_expressions
+            .as_ref()?
             .iter()
             .filter(|r| r.key == NODE_HOSTNAME_KEY && r.operator == "In")
             .find_map(|r| r.values.as_ref()?.get(0).cloned())
@@ -292,19 +395,24 @@ impl Controller {
 
         let storage_classes = Api::<StorageClass>::all(self.client());
 
-        storage_classes.entry(&DYNAMIC_STORAGE_CLASS_NAME)
+        storage_classes
+            .entry(&DYNAMIC_STORAGE_CLASS_NAME)
             .await?
             .or_insert(|| {
-                println!("Creating dynamic StorageClass {}", *DYNAMIC_STORAGE_CLASS_NAME);
+                println!(
+                    "Creating dynamic StorageClass {}",
+                    *DYNAMIC_STORAGE_CLASS_NAME
+                );
 
                 StorageClass {
                     provisioner: PROVISIONER_NAME.into(),
                     allow_volume_expansion: Some(false),
                     metadata: ObjectMeta {
                         name: Some(STORAGE_CLASS_PER_NODE_NAME_PATTERN.to_owned()),
-                        labels: Some(BTreeMap::from([
-                            (STORAGE_CLASS_CONTROLLING_NODE_LABEL_NAME.into(), "*".into())
-                        ])),
+                        labels: Some(BTreeMap::from([(
+                            STORAGE_CLASS_CONTROLLING_NODE_LABEL_NAME.into(),
+                            "*".into(),
+                        )])),
                         ..ObjectMeta::default()
                     },
                     ..StorageClass::default()
@@ -324,102 +432,127 @@ impl Controller {
     /// - `node_name` - The name of the Node the Job should schedule its Pod on
     /// - `args` - CLI arguments for the btrfs-provisioner binary
     /// - `job_type` - A [JobType] to use for finding existing Jobs
-    async fn run_provisioner_job(&self, name: &str, node_name: &str, args: &[&str], job_type: ProvisionerJobType) -> Result<RunJobResult> {
+    async fn run_provisioner_job(
+        &self,
+        name: &str,
+        node_name: &str,
+        args: &[&str],
+        job_type: ProvisionerJobType,
+    ) -> Result<RunJobResult> {
         let jobs = Api::<Job>::namespaced(self.client(), NAMESPACE.as_str());
 
         // Cancel if there already is a job matching job_type's labels
-        if let [existing_lob] = jobs.list(&ListParams {
-            label_selector: Some(job_type.to_label_selector()),
-            limit: Some(1),
-            ..ListParams::default()
-        }).await?.items.as_slice() {
+        if let [existing_lob] = jobs
+            .list(&ListParams {
+                label_selector: Some(job_type.to_label_selector()),
+                limit: Some(1),
+                ..ListParams::default()
+            })
+            .await?
+            .items
+            .as_slice()
+        {
             return Ok(RunJobResult::AlreadyExisting(existing_lob.to_owned()));
         }
 
         // Deploy the Job...
-        jobs.create(&PostParams::default(), &Job {
-            metadata: ObjectMeta {
-                generate_name: Some(name.to_owned() + "-"),
-                labels: Some(job_type.to_labels()),
-                ..ObjectMeta::default()
-            },
-            spec: Some(JobSpec {
-                ttl_seconds_after_finished: Some(600),
-                template: PodTemplateSpec {
-                    spec: Some(PodSpec {
-                        restart_policy: Some("OnFailure".into()),
-                        node_name: Some(node_name.into()),
-                        service_account_name: Some(SERVICE_ACCOUNT_NAME.into()),
-                        containers: vec![Container {
-                            name: "provisioner".into(),
-                            image: Some(IMAGE.to_owned()),
-                            image_pull_policy: Some("IfNotPresent".into()),
-                            args: Some(args.iter().map(|s| String::from(*s)).collect()),
-                            env: Some(vec![
-                                EnvVar {
-                                    name: HOST_FS_ENV_NAME.into(),
-                                    value: Some("/host".into()),
-                                    ..EnvVar::default()
-                                },
-                                EnvVar {
-                                    name: "NODE_NAME".into(),
-                                    value_from: Some(EnvVarSource {
-                                        field_ref: Some(ObjectFieldSelector {
-                                            field_path: "spec.nodeName".into(),
-                                            ..ObjectFieldSelector::default()
-                                        }),
-                                        ..EnvVarSource::default()
-                                    }),
-                                    ..EnvVar::default()
-                                },
-                                EnvVar {
-                                    name: "VOLUMES_DIR".into(),
-                                    value: Some(VOLUMES_DIR.to_owned()),
-                                    ..EnvVar::default()
-                                },
-                                EnvVar {
-                                    name: "ARCHIVE_ON_DELETE".into(),
-                                    value: Some(if *ARCHIVE_ON_DELETE { "true" } else { "false" }.into()),
-                                    ..EnvVar::default()
-                                },
-                                EnvVar {
-                                    name: "STORAGE_CLASS_PER_NODE_ENABLED".into(),
-                                    value: Some(if *STORAGE_CLASS_PER_NODE_ENABLED { "true" } else { "false" }.into()),
-                                    ..EnvVar::default()
-                                },
-                                EnvVar {
-                                    name: "STORAGE_CLASS_PER_NODE_NAME_PATTERN".into(),
-                                    value: Some(STORAGE_CLASS_PER_NODE_NAME_PATTERN.to_owned()),
-                                    ..EnvVar::default()
-                                },
-                            ]),
-                            security_context: Some(SecurityContext {
-                                privileged: Some(true),
-                                ..SecurityContext::default()
-                            }),
-                            volume_mounts: Some(vec![VolumeMount {
-                                name: "host".into(),
-                                mount_path: "/host".into(),
-                                ..VolumeMount::default()
-                            }]),
-                            ..Container::default()
-                        }],
-                        volumes: Some(vec![Volume {
-                            name: "host".into(),
-                            host_path: Some(HostPathVolumeSource {
-                                path: "/".into(),
-                                ..HostPathVolumeSource::default()
-                            }),
-                            ..Volume::default()
-                        }]),
-                        ..PodSpec::default()
-                    }),
-                    ..PodTemplateSpec::default()
+        jobs.create(
+            &PostParams::default(),
+            &Job {
+                metadata: ObjectMeta {
+                    generate_name: Some(name.to_owned() + "-"),
+                    labels: Some(job_type.to_labels()),
+                    ..ObjectMeta::default()
                 },
-                ..JobSpec::default()
-            }),
-            ..Job::default()
-        }).await?;
+                spec: Some(JobSpec {
+                    ttl_seconds_after_finished: Some(600),
+                    template: PodTemplateSpec {
+                        spec: Some(PodSpec {
+                            restart_policy: Some("OnFailure".into()),
+                            node_name: Some(node_name.into()),
+                            service_account_name: Some(SERVICE_ACCOUNT_NAME.into()),
+                            containers: vec![Container {
+                                name: "provisioner".into(),
+                                image: Some(IMAGE.to_owned()),
+                                image_pull_policy: Some("IfNotPresent".into()),
+                                args: Some(args.iter().map(|s| String::from(*s)).collect()),
+                                env: Some(vec![
+                                    EnvVar {
+                                        name: HOST_FS_ENV_NAME.into(),
+                                        value: Some("/host".into()),
+                                        ..EnvVar::default()
+                                    },
+                                    EnvVar {
+                                        name: "NODE_NAME".into(),
+                                        value_from: Some(EnvVarSource {
+                                            field_ref: Some(ObjectFieldSelector {
+                                                field_path: "spec.nodeName".into(),
+                                                ..ObjectFieldSelector::default()
+                                            }),
+                                            ..EnvVarSource::default()
+                                        }),
+                                        ..EnvVar::default()
+                                    },
+                                    EnvVar {
+                                        name: "VOLUMES_DIR".into(),
+                                        value: Some(VOLUMES_DIR.to_owned()),
+                                        ..EnvVar::default()
+                                    },
+                                    EnvVar {
+                                        name: "ARCHIVE_ON_DELETE".into(),
+                                        value: Some(
+                                            if *ARCHIVE_ON_DELETE { "true" } else { "false" }
+                                                .into(),
+                                        ),
+                                        ..EnvVar::default()
+                                    },
+                                    EnvVar {
+                                        name: "STORAGE_CLASS_PER_NODE_ENABLED".into(),
+                                        value: Some(
+                                            if *STORAGE_CLASS_PER_NODE_ENABLED {
+                                                "true"
+                                            } else {
+                                                "false"
+                                            }
+                                            .into(),
+                                        ),
+                                        ..EnvVar::default()
+                                    },
+                                    EnvVar {
+                                        name: "STORAGE_CLASS_PER_NODE_NAME_PATTERN".into(),
+                                        value: Some(STORAGE_CLASS_PER_NODE_NAME_PATTERN.to_owned()),
+                                        ..EnvVar::default()
+                                    },
+                                ]),
+                                security_context: Some(SecurityContext {
+                                    privileged: Some(true),
+                                    ..SecurityContext::default()
+                                }),
+                                volume_mounts: Some(vec![VolumeMount {
+                                    name: "host".into(),
+                                    mount_path: "/host".into(),
+                                    ..VolumeMount::default()
+                                }]),
+                                ..Container::default()
+                            }],
+                            volumes: Some(vec![Volume {
+                                name: "host".into(),
+                                host_path: Some(HostPathVolumeSource {
+                                    path: "/".into(),
+                                    ..HostPathVolumeSource::default()
+                                }),
+                                ..Volume::default()
+                            }]),
+                            ..PodSpec::default()
+                        }),
+                        ..PodTemplateSpec::default()
+                    },
+                    ..JobSpec::default()
+                }),
+                ..Job::default()
+            },
+        )
+        .await?;
 
         Ok(RunJobResult::Deployed)
     }

--- a/src/controller/provisioner_job_type.rs
+++ b/src/controller/provisioner_job_type.rs
@@ -1,7 +1,7 @@
-use std::collections::BTreeMap;
+use crate::config::*;
 use color_eyre::eyre::{bail, eyre};
 use color_eyre::Result;
-use crate::config::*;
+use std::collections::BTreeMap;
 
 pub struct ProvisionJobArgs {
     pub target_pvc_uid: String,
@@ -29,15 +29,44 @@ impl ProvisionerJobType {
 
         match labels.get(JOB_TYPE_LABEL).unwrap().as_str() {
             JOB_TYPE_PROVISION_VALUE => Ok(ProvisionerJobType::Provision(ProvisionJobArgs {
-                target_pvc_uid: labels.get(JOB_TARGET_UID_LABEL).ok_or_else(|| eyre!("Required label {} missing for type={}", JOB_TARGET_UID_LABEL, JOB_TYPE_PROVISION_VALUE))?.to_owned(),
+                target_pvc_uid: labels
+                    .get(JOB_TARGET_UID_LABEL)
+                    .ok_or_else(|| {
+                        eyre!(
+                            "Required label {} missing for type={}",
+                            JOB_TARGET_UID_LABEL,
+                            JOB_TYPE_PROVISION_VALUE
+                        )
+                    })?
+                    .to_owned(),
             })),
             JOB_TYPE_DELETE_VALUE => Ok(ProvisionerJobType::Delete(DeleteJobArgs {
-                target_pv_uid: labels.get(JOB_TARGET_UID_LABEL).ok_or_else(|| eyre!("Required label {} missing for type={}", JOB_TARGET_UID_LABEL, JOB_TYPE_DELETE_VALUE))?.to_owned(),
+                target_pv_uid: labels
+                    .get(JOB_TARGET_UID_LABEL)
+                    .ok_or_else(|| {
+                        eyre!(
+                            "Required label {} missing for type={}",
+                            JOB_TARGET_UID_LABEL,
+                            JOB_TYPE_DELETE_VALUE
+                        )
+                    })?
+                    .to_owned(),
             })),
-            JOB_TYPE_INITIALIZE_NODE_VALUE => Ok(ProvisionerJobType::InitializeNode(InitializeNodeJobArgs {
-                target_node_uid: labels.get(JOB_TARGET_UID_LABEL).ok_or_else(|| eyre!("Required label {} missing for type={}", JOB_TARGET_UID_LABEL, JOB_TYPE_INITIALIZE_NODE_VALUE))?.to_owned(),
-            })),
-            other_job_type => bail!("Invalid job type: {}", other_job_type)
+            JOB_TYPE_INITIALIZE_NODE_VALUE => {
+                Ok(ProvisionerJobType::InitializeNode(InitializeNodeJobArgs {
+                    target_node_uid: labels
+                        .get(JOB_TARGET_UID_LABEL)
+                        .ok_or_else(|| {
+                            eyre!(
+                                "Required label {} missing for type={}",
+                                JOB_TARGET_UID_LABEL,
+                                JOB_TYPE_INITIALIZE_NODE_VALUE
+                            )
+                        })?
+                        .to_owned(),
+                }))
+            }
+            other_job_type => bail!("Invalid job type: {}", other_job_type),
         }
     }
 

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -1,7 +1,7 @@
-use std::path::PathBuf;
 use color_eyre::eyre::eyre;
 use color_eyre::Result;
 use kube::ResourceExt;
+use std::path::PathBuf;
 
 pub trait ProvisionerResourceExt: ResourceExt {
     /// Returns the full name of the resource in the format `<namespace>/<name>`
@@ -24,6 +24,8 @@ pub trait PathBufExt {
 
 impl PathBufExt for PathBuf {
     fn as_str(&self) -> Result<&str> {
-        return self.to_str().ok_or_else(|| eyre!("Could not convert path to string"))
+        return self
+            .to_str()
+            .ok_or_else(|| eyre!("Could not convert path to string"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,17 @@
-use build_time::build_time_local;
-use crate::provisioner::Provisioner;
-use clap::{Args, Parser};
-use clap::Subcommand;
-use color_eyre::Result;
 use crate::controller::Controller;
+use crate::provisioner::Provisioner;
+use build_time::build_time_local;
+use clap::Subcommand;
+use clap::{Args, Parser};
+use color_eyre::Result;
 
-pub mod ext;
-pub mod provisioner;
-pub mod controller;
-pub mod quantity_parser;
-pub mod config;
 pub mod btrfs_volume_metadata;
 pub mod btrfs_wrapper;
+pub mod config;
+pub mod controller;
+pub mod ext;
+pub mod provisioner;
+pub mod quantity_parser;
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
@@ -32,7 +32,10 @@ struct ProvisionArgs {
     pvc_namespace: String,
     pvc_name: String,
 
-    #[clap(env = "NODE_NAME", help = "The name of the Node the provisioner runs on")]
+    #[clap(
+        env = "NODE_NAME",
+        help = "The name of the Node the provisioner runs on"
+    )]
     node_name: String,
 }
 
@@ -40,13 +43,19 @@ struct ProvisionArgs {
 struct DeleteArgs {
     pv_name: String,
 
-    #[clap(env = "NODE_NAME", help = "The name of the Node the provisioner runs on")]
+    #[clap(
+        env = "NODE_NAME",
+        help = "The name of the Node the provisioner runs on"
+    )]
     node_name: String,
 }
 
 #[derive(Args)]
 struct InitializeNodeArgs {
-    #[clap(env = "NODE_NAME", help = "The name of the Node the provisioner runs on")]
+    #[clap(
+        env = "NODE_NAME",
+        help = "The name of the Node the provisioner runs on"
+    )]
     node_name: String,
 }
 
@@ -54,7 +63,11 @@ struct InitializeNodeArgs {
 async fn main() -> Result<()> {
     color_eyre::install()?;
 
-    println!("Running btrfs-provisioner v{} built at {}", config::VERSION, build_time_local!());
+    println!(
+        "Running btrfs-provisioner v{} built at {}",
+        config::VERSION,
+        build_time_local!()
+    );
 
     let cli = Cli::parse();
 
@@ -83,9 +96,6 @@ async fn main() -> Result<()> {
             }
         }
     } else {
-        Controller::create()
-            .await?
-            .run()
-            .await
+        Controller::create().await?.run().await
     }
 }

--- a/src/quantity_parser.rs
+++ b/src/quantity_parser.rs
@@ -24,7 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-use color_eyre::{Result, Report, eyre::eyre};
+use color_eyre::{eyre::eyre, Report, Result};
 use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
 use regex::Regex;
 


### PR DESCRIPTION
Everyone's favorite drive by PR: a lint/format cleanup that changes half the files.

I'm submitting this to bring the codebase back in line w/ rust fmt norms; doing so may seem pedantic, but it's annoying when one is working on a PR and the codebase formatting diverges from the community/global standard ;)

In terms of what this was: `cargo fmt`, from `cargo 1.74.0 (ecb9851af 2023-10-18)`