### PR TITLE
Require nightly for the toolchain.

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
To build this already requires nightly, thus just mark the toolchain requirements accordingly.